### PR TITLE
Loosen activesupport pin to allow Rails 8 upgrades

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     dor-event-client (1.0.0)
-      activesupport (>= 4.2, < 8)
+      activesupport (>= 4.2)
       bunny (~> 2.17)
       zeitwerk (~> 2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2.1)
+    activesupport (8.0.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -21,6 +21,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     amq-protocol (2.3.2)
     ast (2.4.2)
     base64 (0.2.0)
@@ -39,7 +40,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.9.1)
     language_server-protocol (3.17.0.4)
-    logger (1.6.5)
+    logger (1.6.6)
     minitest (5.25.4)
     parallel (1.26.3)
     parser (3.3.7.1)
@@ -103,6 +104,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.2)
     zeitwerk (2.7.1)
 
 PLATFORMS

--- a/dor-event-client.gemspec
+++ b/dor-event-client.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0', '< 4'
 
-  spec.add_dependency 'activesupport', '>= 4.2', '< 8'
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'bunny', '~> 2.17' # Send messages to RabbitMQ
   spec.add_dependency 'zeitwerk', '~> 2.1'
 


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change affects the API or other fundamentals of this service, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡



